### PR TITLE
Changed installation to cleanup only extensions from the repository

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,10 @@ task wrapper(type: Wrapper) {
 }
 
 task cleanInstall(type: Delete) {
-	delete installExtDir
+    fileTree(dir: 'build/extensions').each { file ->
+        def basename = file.name.split('/')[-1]
+        delete installExtDir + '/' + basename
+    }
 }
 
 task prepareExtensions(type: Copy) {


### PR DESCRIPTION
Hi, Marco!

I noticed that the build file is removing all the contents of `~/.gvm/ext` on installation, potentially losing the user's own extensions.
I thought I'd made a small change for it to delete only the files matching the ones in the current project.
